### PR TITLE
Update validator.ts

### DIFF
--- a/src/renderer/utils/validator.ts
+++ b/src/renderer/utils/validator.ts
@@ -1,1 +1,1 @@
-export const domainFormat = /^[a-zA-Z0-9][a-zA-Z0-9-.]{0,61}[a-zA-Z0-9]\.[a-zA-Z0-9]{2,}$/
+export const domainFormat = /^(((?!\-))(xn\-\-)?[a-z0-9\-_]{0,61}[a-z0-9]{1,1}\.)*(xn\-\-)?([a-z0-9\-]{1,61}|[a-z0-9\-]{1,30})\.[a-z]{2,}$/


### PR DESCRIPTION
## Description
Seems like at least one of the issues for domain/subdomain validation in the Whalebird-desktop app is the regex used. Taken from [StackOverflow](https://stackoverflow.com/questions/10306690/what-is-a-regular-expression-which-will-match-a-valid-domain-name-without-a-subd) this patch replaces the existing regex with one that validates 'c.im' correctly yet avoids issues with subdomain validation.

## Related Issues
3722

